### PR TITLE
Allow pairingInfo to be null in sample

### DIFF
--- a/Sample Code/sample/src/main/java/com/pingidentity/pingone/MobileAuthenticationFrameworkActivity.java
+++ b/Sample Code/sample/src/main/java/com/pingidentity/pingone/MobileAuthenticationFrameworkActivity.java
@@ -92,7 +92,7 @@ public class MobileAuthenticationFrameworkActivity extends AppCompatActivity {
                             }
 
                             @Override
-                            public void onComplete(PairingInfo pairingInfo, @Nullable final PingOneSDKError pingOneSDKError) {
+                            public void onComplete(@Nullable PairingInfo pairingInfo, @Nullable final PingOneSDKError pingOneSDKError) {
                                 this.onComplete(pingOneSDKError);
                             }
                         });

--- a/Sample Code/sample/src/main/java/com/pingidentity/pingone/OIDCActivity.java
+++ b/Sample Code/sample/src/main/java/com/pingidentity/pingone/OIDCActivity.java
@@ -160,7 +160,7 @@ public class OIDCActivity extends AppCompatActivity {
                     public void onClick(DialogInterface dialog, int which) {
                         pairingObject.approve(OIDCActivity.this, new PingOne.PingOneSDKPairingCallback() {
                             @Override
-                            public void onComplete(PairingInfo pairingInfo, @Nullable PingOneSDKError error) {
+                            public void onComplete(@Nullable PairingInfo pairingInfo, @Nullable PingOneSDKError error) {
                                 this.onComplete(error);
                             }
 

--- a/Sample Code/sample/src/main/java/com/pingidentity/pingone/PairActivity.java
+++ b/Sample Code/sample/src/main/java/com/pingidentity/pingone/PairActivity.java
@@ -44,7 +44,7 @@ public class PairActivity extends SampleActivity {
                 String activationCode = activationCodeInput.getText().toString();
                 PingOne.pair(PairActivity.this, activationCode, new PingOne.PingOneSDKPairingCallback() {
                     @Override
-                    public void onComplete(PairingInfo pairingInfo, @Nullable PingOneSDKError error) {
+                    public void onComplete(@Nullable PairingInfo pairingInfo, @Nullable PingOneSDKError error) {
                             this.onComplete(error);
                     }
 


### PR DESCRIPTION
Allowing `pairingInfo` to be null fixes a crash we noticed on Android pairing a device for the second time. Updating the example docs here so others don't run into the same issue. 

Thanks to @lipidity for the fix

This may be a fix for the following issue https://github.com/pingidentity/pingone-mobile-sdk-android/issues/16
